### PR TITLE
Rôles : modification sans validation et modification avant validation pédagogique

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# esup-pstage
-
- forked from EsupPortail/esup-pstage

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# esup-pstage
+
+ forked from EsupPortail/esup-pstage

--- a/esup-pstage-domain-services/src/main/resources/META-INF/misc/application.xml
+++ b/esup-pstage-domain-services/src/main/resources/META-INF/misc/application.xml
@@ -39,7 +39,7 @@
 	    		The minor number of the application (2 for version 1.2.3).
 	    	</description>
     	</property>
-    	<property name="versionUpdate" value="0" >
+    	<property name="versionUpdate" value="1" >
 	    	<description>
 	    		The update of the application (3 for version 1.2.3).
 	    	</description>

--- a/esup-pstage-utils/src/main/java/org/esupportail/pstage/utils/DonneesStatic.java
+++ b/esup-pstage-utils/src/main/java/org/esupportail/pstage/utils/DonneesStatic.java
@@ -57,7 +57,12 @@ public class DonneesStatic {
 	/**
 	 * valeur pour les droits en écriture avant validation pédagogique
 	 */
-	public static final String LIBELLE_DROIT_ECRITURE_AVANT_VALP = "ECRITURE SANS VALIDATION";
+	public static final String LIBELLE_DROIT_ECRITURE_AVANT_VALP = "ECRITURE AVANT VALP";
+
+	/**
+	 * valeur pour les droits en écriture sans validation de convention
+	 */
+	public static final String LIBELLE_DROIT_ECRITURE_SANS_VALIDATION = "ECRITURE SANS VALIDATION";
 	
 	/**
 	 * valeur de la civilite Monsieur dans le ldap

--- a/esup-pstage-web-jsf-servlet/src/main/java/org/esupportail/pstage/web/controllers/BeanUtils.java
+++ b/esup-pstage-web-jsf-servlet/src/main/java/org/esupportail/pstage/web/controllers/BeanUtils.java
@@ -666,10 +666,45 @@ public class BeanUtils extends AbstractDomainAwareBean {
 		return droitLecture;
 	}
 
+
 	/**
 	 * String
 	 */
-	private String libelleDroitEcritureAvantValP = "ECRITURE_AVANT_VALP";
+	private String libelleDroitEcritureSansValidation = "ECRITURE SANS VALIDATION";
+
+	/**
+	 * @return the libelleDroitAdmin
+	 */
+	public String getLibelleDroitEcritureSansValidation() {
+		return libelleDroitEcritureSansValidation;
+	}
+
+	/**
+	 * Objet DroitEcriture
+	 */
+	private DroitAdministrationDTO droitEcritureSansValidation;
+	/**
+	 * @return DroitAdministrationDTO
+	 */
+	public DroitAdministrationDTO getDroitEcritureSansValidation() {
+		droitEcritureSansValidation = null;
+
+		List<DroitAdministrationDTO> l = getNomenclatureDomainService().getDroitsAdmin();
+
+		for (DroitAdministrationDTO c : l) {
+			if (c.getLibelle().equalsIgnoreCase(DonneesStatic.LIBELLE_DROIT_ECRITURE_SANS_VALIDATION)) {
+				droitEcritureSansValidation = c;
+			}
+		}
+
+		return droitEcritureSansValidation;
+	}
+
+
+	/**
+	 * String
+	 */
+	private String libelleDroitEcritureAvantValP = "ECRITURE AVANT VALP";
 
 	/**
 	 * @return the libelleDroitAdmin

--- a/esup-pstage-web-jsf-servlet/src/main/java/org/esupportail/pstage/web/controllers/ConventionController.java
+++ b/esup-pstage-web-jsf-servlet/src/main/java/org/esupportail/pstage/web/controllers/ConventionController.java
@@ -990,7 +990,8 @@ public class ConventionController extends AbstractContextAwareController {
 							DroitAdministrationDTO droits = getSessionController().getDroitsAccesMap().get(centreGestionRattachement.getIdCentreGestion());
 							if (droits != null && (droits.getLibelle().equalsIgnoreCase(DonneesStatic.LIBELLE_DROIT_ECRITURE)
 									|| droits.getLibelle().equalsIgnoreCase(DonneesStatic.LIBELLE_DROIT_ADMIN)
-									|| droits.getLibelle().equalsIgnoreCase(DonneesStatic.LIBELLE_DROIT_ECRITURE_AVANT_VALP))) {
+									|| droits.getLibelle().equalsIgnoreCase(DonneesStatic.LIBELLE_DROIT_ECRITURE_AVANT_VALP)
+									|| droits.getLibelle().equalsIgnoreCase(DonneesStatic.LIBELLE_DROIT_ECRITURE_SANS_VALIDATION))) {
 								// Si le personnel a bien les droits Ecriture ou
 								// Admin sur le centre, on autorise la création
 								creationAutorisee = true;

--- a/esup-pstage-web-jsf-servlet/src/main/java/org/esupportail/pstage/web/controllers/WelcomeController.java
+++ b/esup-pstage-web-jsf-servlet/src/main/java/org/esupportail/pstage/web/controllers/WelcomeController.java
@@ -963,8 +963,9 @@ public class WelcomeController extends AbstractContextAwareController {
 		connectStage();
 		Map<Integer,DroitAdministrationDTO> map = getSessionController().getDroitsAccesMap();
 		if (map != null && !(map.isEmpty())){
-			if(map.containsValue(getBeanUtils().getDroitEcriture()) ||
-					map.containsValue(getBeanUtils().getDroitEcritureAvantValP())) {
+			if(map.containsValue(getBeanUtils().getDroitEcriture())
+					|| map.containsValue(getBeanUtils().getDroitEcritureAvantValP())
+					|| map.containsValue(getBeanUtils().getDroitEcritureSansValidation())) {
 				isWriter = true;
 			}
 		}

--- a/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape1Etudiant.xhtml
+++ b/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape1Etudiant.xhtml
@@ -74,11 +74,13 @@
                                          onstart="PF('statusDialog').show();" oncomplete="PF('statusDialog').hide();"
                                          styleClass="mt15 ml20"
                                          rendered="#{not empty conventionController.convention.etudiant and !conventionController.conventionValide
-                                and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
-                                || (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP)))}" />
+						and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
+						|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion]
+						and ( sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+							|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+								and !conventionController.convention.validationPedagogique))))}" />
                     </t:div>
                 </t:fieldset>
             </h:form>

--- a/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape2Etab.xhtml
+++ b/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape2Etab.xhtml
@@ -25,17 +25,19 @@
 
                             <p:commandButton id="modifEtab" value="#{msgs['FORM.MODIFIER']} ces informations"
                                              action="#{conventionController.goToConventionModifEtab}"
-                                             rendered="#{not empty conventionController.convention.structure and !conventionController.conventionValide
-                                and ((sessionController.adminPageAuthorized || sessionController.pageAuthorized ||
-                                    (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                    (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                    || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                    || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP)))
-                                || (welcomeController.etudiant and ((sessionController.autoriserEtudiantAModifierEntreprise ||
-                                (!sessionController.autoriserEtudiantAModifierEntreprise
-                                and ((empty conventionController.convention.structure.loginModif and
-                                conventionController.convention.structure.loginCreation==sessionController.currentLogin)
-                                || (conventionController.convention.structure.loginModif==sessionController.currentLogin)))))))}">
+						rendered="#{not empty conventionController.convention.structure and !conventionController.conventionValide
+							and ((sessionController.adminPageAuthorized || sessionController.pageAuthorized
+							|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion]
+								and sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+								|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+								|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+								|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+									and !conventionController.convention.validationPedagogique)))
+								|| (welcomeController.etudiant and ((sessionController.autoriserEtudiantAModifierEntreprise ||
+								(!sessionController.autoriserEtudiantAModifierEntreprise
+								and ((empty conventionController.convention.structure.loginModif and
+								conventionController.convention.structure.loginCreation==sessionController.currentLogin)
+								|| (conventionController.convention.structure.loginModif==sessionController.currentLogin)))))))}">
                                 <f:setPropertyActionListener
                                         value="#{conventionController.convention.structure}"
                                         target="#{etablissementController.formStructure}" />
@@ -44,12 +46,14 @@
                             <p:commandButton value="#{msgs['RECHERCHEETABLISSEMENT.RECHERCHER.AUTRE']}"
                                              oncomplete="PF('demandeConfirmModifEtab').show();"
                                              styleClass="ml20"
-                                             rendered="#{not empty conventionController.convention.structure and !conventionController.conventionValide
-                                        and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
-                                        || (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                        (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                        || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                        || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP)))}" />
+					rendered="#{not empty conventionController.convention.etudiant and !conventionController.conventionValide
+						and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
+						|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion]
+						and ( sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+							|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+								and !conventionController.convention.validationPedagogique))))}" />
                         </t:div>
 
                         <t:htmlTag value="div" style="height:15px;" />

--- a/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape3Service.xhtml
+++ b/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape3Service.xhtml
@@ -44,12 +44,15 @@
                                     <p:commandButton id="selC" styleClass="fontBlue2"
                                                      value="#{msgs['CONVENTION.MODIF.SERVICE.BOUTON']}"
                                                      oncomplete="PF('demandeConfirmModifService').show();"
-                                                     rendered="#{!conventionController.conventionValide
-                                            and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
-                                            || (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                            (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                            || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                            || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP)))}"/>
+							rendered="#{not empty conventionController.convention.etudiant and !conventionController.conventionValide
+								and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
+								|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion]
+								and ( sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+									|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+									|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+									|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+										and !conventionController.convention.validationPedagogique))))}" />
+
                                 </t:div>
 
                                 <p:dialog id="demandeConfirmModifService"

--- a/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape4Contact.xhtml
+++ b/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape4Contact.xhtml
@@ -77,17 +77,19 @@
                             <t:div styleClass="textCenter mt15">
                                 <p:commandButton oncomplete="PF('modifContact').show();"
                                                  update="modifContact" value="#{msgs['FORM.MODIFIER']} les informations de ce contact"
-                                                 rendered="#{not empty conventionController.convention.contact and !conventionController.conventionValide
-								and ((sessionController.adminPageAuthorized || sessionController.pageAuthorized
-								|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP)))
-								|| (welcomeController.etudiant and ((sessionController.autoriserEtudiantAModifierEntreprise ||
-								(!sessionController.autoriserEtudiantAModifierEntreprise
-								and ((empty conventionController.convention.contact.loginModif and
-								conventionController.convention.contact.loginCreation==sessionController.currentLogin)
-								|| (conventionController.convention.contact.loginModif==sessionController.currentLogin)))))))}">
+                        			 rendered="#{not empty conventionController.convention.contact and !conventionController.conventionValide
+							and ((sessionController.adminPageAuthorized || sessionController.pageAuthorized
+							|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
+			                                (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+			                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+			                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+							|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+								and !conventionController.convention.validationPedagogique))))
+							|| (welcomeController.etudiant and ((sessionController.autoriserEtudiantAModifierEntreprise ||
+							(!sessionController.autoriserEtudiantAModifierEntreprise
+							and ((empty conventionController.convention.contact.loginModif and
+							conventionController.convention.contact.loginCreation==sessionController.currentLogin)
+							|| (conventionController.convention.contact.loginModif==sessionController.currentLogin)))))))}">
                                     <f:setPropertyActionListener
                                             value="#{conventionController.convention.contact}"
                                             target="#{etablissementController.formContact}" />
@@ -100,12 +102,14 @@
                                 <p:commandButton update="selectServiceContact"
                                                  oncomplete="PF('selectServiceContact').show();"
                                                  styleClass="ml20"
-                                                 rendered="#{!conventionController.conventionValide
-		                        and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
-		                        || (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP)))}"
+                                                 rendered="#{not empty conventionController.convention.etudiant and !conventionController.conventionValide
+							and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
+							|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion]
+							and ( sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+								|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+								|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+								|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+									and !conventionController.convention.validationPedagogique))))}"
                                                  value="#{msgs['CONVENTION.ETAPE4.MODIF.CONTACT']}">
                                     <f:setPropertyActionListener value="#{0}"
                                                                  target="#{etablissementController.idContactSel}" />

--- a/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape5Stage.xhtml
+++ b/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape5Stage.xhtml
@@ -25,12 +25,14 @@
                         <t:div styleClass="mt10 ml40">
                             <p:commandButton id="modifStage" value="#{msgs['FORM.MODIFIER']}"
                                              action="conventionEtape5ModifStage" update="@form"
-                                             rendered="#{(not empty conventionController.convention and !conventionController.conventionValide) and (welcomeController.superAdmin
-									|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                    (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                    || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                    || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP))
-									|| welcomeController.etudiant)}" />
+                                             rendered="#{not empty conventionController.convention.etudiant and !conventionController.conventionValide
+						and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
+						|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion]
+						and ( sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+							|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+								and !conventionController.convention.validationPedagogique))))}" />
                         </t:div>
                     </t:div>
                 </t:fieldset>

--- a/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape6Enseignant.xhtml
+++ b/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape6Enseignant.xhtml
@@ -25,13 +25,14 @@
                                              value="#{msgs['CONVENTION.ETAPE6.MODIF.ENSEIGNANT']}"
                                              action="#{conventionController.goToConventionModifEnseignant}"
                                              styleClass="mt15 ml40"
-                                             rendered="#{!conventionController.conventionValide
-                                             and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
-                                            || (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                            (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                            || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                            || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP)))}" />
-
+                                             rendered="#{not empty conventionController.convention.etudiant and !conventionController.conventionValide
+						and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
+						|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion]
+						and ( sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+							|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+								and !conventionController.convention.validationPedagogique))))}" />
                         </t:div>
 
                         <p:messages />

--- a/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape7Signataire.xhtml
+++ b/esup-pstage-web-jsf-servlet/src/main/webapp/stylesheets/stage/conventionEtape7Signataire.xhtml
@@ -76,18 +76,20 @@
                             <t:div styleClass="textCenter mt15">
                                 <p:commandButton value="#{msgs['FORM.MODIFIER']} les informations de ce contact"
                                                  oncomplete="PF('modifContact').show();" update="modifContact"
-                                                 rendered="#{not empty conventionController.convention.signataire and !conventionController.conventionValide
-                                    and ((sessionController.adminPageAuthorized || sessionController.pageAuthorized
-                                    || (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                    (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                    || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                    || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP)))
-                                    || (welcomeController.etudiant and ((sessionController.autoriserEtudiantAModifierEntreprise ||
-                                    (!sessionController.autoriserEtudiantAModifierEntreprise
-                                    and ((empty conventionController.convention.contact.loginModif and
-                                    conventionController.convention.contact.loginCreation==sessionController.currentLogin)
-                                    || (conventionController.convention.contact.loginModif==sessionController.currentLogin)))))))}">
-                                    <f:setPropertyActionListener
+                                		rendered="#{not empty conventionController.convention.signataire and !conventionController.conventionValide
+			                                    and ((sessionController.adminPageAuthorized || sessionController.pageAuthorized
+			                                    || (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
+			                                    (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+			                                    || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+			                                    || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+												|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+													and !conventionController.convention.validationPedagogique))))
+			                                    || (welcomeController.etudiant and ((sessionController.autoriserEtudiantAModifierEntreprise ||
+			                                    (!sessionController.autoriserEtudiantAModifierEntreprise
+			                                    and ((empty conventionController.convention.contact.loginModif and
+			                                    conventionController.convention.contact.loginCreation==sessionController.currentLogin)
+			                                    || (conventionController.convention.contact.loginModif==sessionController.currentLogin)))))))}">
+		                    <f:setPropertyActionListener
                                             value="#{conventionController.convention.signataire}"
                                             target="#{etablissementController.formContact}" />
                                     <f:setPropertyActionListener value="#{false}"
@@ -99,12 +101,14 @@
                                         value="#{msgs['CONVENTION.ETAPE7.MODIF.SIGNATAIRE']}"
                                         oncomplete="PF('selectServiceSignataire').show();"
                                         styleClass="ml20"
-                                        rendered="#{!conventionController.conventionValide
-                                    and (welcomeController.superAdmin || welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
-                                    || (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] and
-                                (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
-                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
-                                || sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP)))}">
+                                        rendered="#{not empty conventionController.convention.etudiant and !conventionController.conventionValide
+						and (welcomeController.etudiant || sessionController.adminPageAuthorized || sessionController.pageAuthorized
+						|| (not empty sessionController.droitsAccesMap[conventionController.convention.idCentreGestion]
+						and ( sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitAdmin
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcriture
+							|| sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureSansValidation
+							|| (sessionController.droitsAccesMap[conventionController.convention.idCentreGestion] == beanUtils.droitEcritureAvantValP
+								and !conventionController.convention.validationPedagogique))))}">
                                     <f:setPropertyActionListener value="#{0}"
                                                                  target="#{etablissementController.idContactSel}" />
                                     <f:setPropertyActionListener value="#{null}"


### PR DESCRIPTION
Bonjour,

A l'Université de Bordeaux, nous utilisons un rôle supplémentaire qui pourrait intéresser d'autres universités : il s'agit de l'ECRITURE AVANT VALP qui permet au gestionnaire de modifier les informations de la conventions jusqu'à ce qu'elle soit validée par l'enseignant.

J'avais eu il y a quelques mois des échanges avec Florian à ce sujet et une partie des modifications a été intégrée à la release 3.0.0 pour la création du rôle ECRITURE SANS VALIDATION.

Ce pull request reprend l'ensemble de ces modifs pour la mise en place des 2 rôles.

Bonne continuation 
Julien Lemonnier
Université de Bordeaux
